### PR TITLE
1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The main menu shows 4 options.
 
 ### 1) Order favourites...   
 Opens a dialog where you can view and reorder your Favourites items.   
-- To reorder items, select an item to "mark" it, then select another item to **swap their place**.
+- To reorder items, select an item to "mark" it, then select another item to **swap their place**.  
 (If an item is marked, you can select it again to unmark it.)  
 - Press the Close button to close that dialog when you're done editing. Your changes won't be saved yet.
 - If you've made some mistakes and want to start over, press the "Restore..." button to restore the favourites order from the Kodi favourites file, or also close the dialog and re-open it. This will undo your unsaved changes.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ The main menu shows 4 options.
 
 ### 1) Order favourites...   
 Opens a dialog where you can view and reorder your Favourites items.   
-- To reorder items, select an item to "mark" it, then select another item to move the marked item there.  
-(The marked item will be placed in **front** of the other item.)  
+- To reorder items, select an item to "mark" it, then select another item to **swap their place**.
 (If an item is marked, you can select it again to unmark it.)  
-- Press the Close button to close that dialog when you're done editing (your changes won't be saved yet).  
-- If you've made some mistakes and want to start over, press the "Restore..." button to restore the favourites order from the Kodi favourites file. This will undo your unsaved changes.
+- Press the Close button to close that dialog when you're done editing. Your changes won't be saved yet.
+- If you've made some mistakes and want to start over, press the "Restore..." button to restore the favourites order from the Kodi favourites file, or also close the dialog and re-open it. This will undo your unsaved changes.
    
 ### 2) Save and reload
 Saves your changes and reloads your Kodi profile, so your changes can be seen immediately instead of you having to restart Kodi to see them.

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.orderfavourites" name="Order Favourites" version="1.2.3" provider-name="doko">
+<addon id="plugin.program.orderfavourites" name="Order Favourites" version="1.3.0" provider-name="doko">
   <requires>
     <import addon="xbmc.python" version="3.0.0"/>
   </requires>
@@ -9,6 +9,10 @@
   <extension point="xbmc.addon.metadata">
     <news>
 [COLOR lavender][B]Order Favourites[/B][/COLOR]
+[B]1.3.0:[/B]
+- Changed the movement method to "Swap item A and B". The old method used to be
+"Remove A and re-insert it around B", confusing and disruptive.
+
 [B]1.2.3:[/B]
 - Add-on metadata update with an icon fix.
 


### PR DESCRIPTION
Changed the ordering behavior to "Swap item A and B".  
The old method used to be "Remove A and re-insert it around B", which was confusing and disruptive.

See this comment for more info: https://github.com/doko-desuka/plugin.program.orderfavourites/issues/10#issuecomment-1861211380